### PR TITLE
Update site to remove ARM application link

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,14 +113,14 @@
     </div>
     <div class="span10">
       <h2>How do I get an account?</h2>
-      <p>For access to the ARM zone, please submit your request via <a href="http://eepurl.com/nGEzj">http://eepurl.com/nGEzj</a>.
+      <p>The ARM zone is not currently accepting new users.</a>.
       </p>
       <p>For access to the x86 zone, join our Facebook Group. We'll post updates there. (We hear you about Facebook and we're working on adding other alternatives, too.)</p>
       <p>At the moment, we are approving group requests manually, so please allow up to a couple days to process your request. </p>
 
 <div class="alert alert-info"><p><strong>IMPORTANT NOTE:</strong> In order to log in with the Facebook link, you must be a member of the TryStack Facebook group. You cannot use the API endpoint until we find a way to give you your password, so please be patient while we work on the backlog of features.</p></div>
       <h2>How long does creating an account take?</h2>
-      <p>There's a manual approval step in our process, so it may take a little time for you to get access to TryStack. Please be patient. We're imagining quite a few accounts will be requested at launch, but we want to add users carefully.</p>
+      <p>There's a manual approval step in our process, so it may take a little time for you to get access to TryStack. Please be patient.</p>
     </div>
   </div><!--/row-->
 


### PR DESCRIPTION
The ARM zone has not accepted any new users for a while.

Therefore, the link should be updated with appropriate
text that reflects this.
